### PR TITLE
Fix LottiePlayer Transition Events Initialization Timing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lottielab/lottie-player",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lottielab/lottie-player",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "lottie-web": "github:lottielab/lottie-web#c671e8eaefb95099fdb126d2fc68a566327e4354"

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -41,7 +41,7 @@ export type LottieProps = LottiePropsBase &
 
 const LottieReact = forwardRef<ILottie, LottieProps>((props, ref) => {
   const player = useRef<LottiePlayer | null>(null);
-  const [isInitilized, setIsInitilized] = useState(false);
+  const [isInitialized, setIsInitialized] = useState(false);
   const container = useCallback((node: HTMLDivElement | null) => {
     if (node) {
       player.current = new LottiePlayer(node);
@@ -103,7 +103,7 @@ const LottieReact = forwardRef<ILottie, LottieProps>((props, ref) => {
       preserveAspectRatio,
       onSuccess: function () {
         props.onLoad?.();
-        setIsInitilized(true);
+        setIsInitialized(true);
       },
       onError: function (error) {
         warn(error);
@@ -182,24 +182,24 @@ const LottieReact = forwardRef<ILottie, LottieProps>((props, ref) => {
   }, [props.onFinish]);
 
   useEffect(() => {
-    if (!props.onTransitionStart || !isInitilized) return;
+    if (!props.onTransitionStart || !isInitialized) return;
     function listener(e: TransitionEvent) {
       props.onTransitionStart?.(e);
     }
 
     player.current?.interactivity?.on('transitionstart', listener);
     return () => player.current?.interactivity?.off('transitionstart', listener);
-  }, [props.onTransitionStart, isInitilized]);
+  }, [props.onTransitionStart, isInitialized]);
 
   useEffect(() => {
-    if (!props.onTransitionEnd || !isInitilized) return;
+    if (!props.onTransitionEnd || !isInitialized) return;
     function listener(e: TransitionEvent) {
       props.onTransitionEnd?.(e);
     }
 
     player.current?.interactivity?.on('transitionend', listener);
     return () => player.current?.interactivity?.off('transitionend', listener);
-  }, [props.onTransitionEnd, isInitilized]);
+  }, [props.onTransitionEnd, isInitialized]);
 
   const { className, style } = props;
   return (


### PR DESCRIPTION
I had an issue #9 where transition events would not trigger until the lottie re-rendered.

```ts
  useEffect(() => {
    try {
      const autoplay =
        'playing' in props && props.playing != undefined
          ? props.playing
          : 'autoplay' in props
            ? props.autoplay
            : true;

      player.current
        ?.initialize('src' in props ? props.src : props.lottie, autoplay, props.preserveAspectRatio)
        .catch((e) => {
          warn(e);
          props.onError?.(e);
        })
        .then(() => props.onLoad?.());
    } catch (e) {
      warn(e);
      props.onError?.(e);
    }

    return () => player.current?.destroy();
  }, ['src' in props ? props.src : props.lottie, props.preserveAspectRatio]);
```

This useEffect is responsible for calling the asynchronous .initialize method on LottiePlayer, and .initialize would complete after dependent effects, causing race conditions.

```ts
  useEffect(() => {
    if (!props.onTransitionStart) return;
    function listener(e: TransitionEvent) {
      props.onTransitionStart?.(e);
    }

    player.current?.interactivity?.on('transitionstart', listener);
    return () => player.current?.interactivity?.off('transitionstart', listener);
  }, [props.onTransitionStart]);
```

`player.current?.interactivity?.on` would fail in this case because `player.current?.interactivity` would return `undefined`. It needs to wait for `LottiePlayer.initialize` to run correctly. It would only run again if `props.onTransitionStart` were to re-render.

I fixed it by adding a isInitialized state, there is probably a better way tho.

